### PR TITLE
Feature/#23

### DIFF
--- a/src/PedigreeCalculator.js
+++ b/src/PedigreeCalculator.js
@@ -55,13 +55,51 @@ const calYatch = (counts) => {
   return flag ? 50 : 0;
 };
 
-export {
-  makeCountArray,
-  calSum,
-  calSingle,
-  cal4OfAKind,
-  calFullHouse,
-  calSmallStraight,
-  calLargeStraight,
-  calYatch,
+const calculate = (title, dice) => {
+  if (!title || !dice) return null;
+  let result = 0;
+  const counts = makeCountArray(dice);
+  switch (title) {
+    case "Aces":
+      result = calSingle(counts, 1);
+      break;
+    case "Duces":
+      result = calSingle(counts, 2);
+      break;
+    case "Threes":
+      result = calSingle(counts, 3);
+      break;
+    case "Fours":
+      result = calSingle(counts, 4);
+      break;
+    case "Fives":
+      result = calSingle(counts, 5);
+      break;
+    case "Sixes":
+      result = calSingle(counts, 6);
+      break;
+    case "Choice":
+      result = calSum(counts);
+      break;
+    case "4 Of a Kind":
+      result = cal4OfAKind(counts);
+      break;
+    case "Full House":
+      result = calFullHouse(counts);
+      break;
+    case "Small Straight":
+      result = calSmallStraight(counts);
+      break;
+    case "Large Straight":
+      result = calLargeStraight(counts);
+      break;
+    case "Yacht":
+      result = calYatch(counts);
+      break;
+    default:
+      break;
+  }
+  return result;
 };
+
+export { calculate };

--- a/src/PedigreeCalculator.js
+++ b/src/PedigreeCalculator.js
@@ -1,0 +1,67 @@
+const makeCountArray = (dices) => {
+  const counts = [0, 0, 0, 0, 0, 0];
+  dices.map((v) => {
+    counts[v - 1]++;
+  });
+  return counts;
+};
+
+const calSum = (counts) => {
+  let sum = 0;
+  counts.map((v, i) => (sum += v * (i + 1)));
+  return sum;
+};
+
+const calSingle = (counts, num) => {
+  return counts[num - 1] * num;
+};
+
+const cal4OfAKind = (counts) => {
+  const flag = counts.some((v) => v >= 4);
+  return flag ? calSum(counts) : 0;
+};
+
+const calFullHouse = (counts) => {
+  const flag = counts.some((v) => v == 3) && counts.some((v) => v == 2);
+
+  return flag ? calSum(counts) : 0;
+};
+
+const calSmallStraight = (counts) => {
+  const flag =
+    (counts[0] > 0 && counts[1] > 0 && counts[2] > 0 && counts[3] > 0) ||
+    (counts[1] > 0 && counts[2] > 0 && counts[3] > 0 && counts[4] > 0) ||
+    (counts[2] > 0 && counts[3] > 0 && counts[4] > 0 && counts[5] > 0);
+  return flag ? 15 : 0;
+};
+
+const calLargeStraight = (counts) => {
+  const flag =
+    (counts[0] > 0 &&
+      counts[1] > 0 &&
+      counts[2] > 0 &&
+      counts[3] > 0 &&
+      counts[4] > 0) ||
+    (counts[1] > 0 &&
+      counts[2] > 0 &&
+      counts[3] > 0 &&
+      counts[4] > 0 &&
+      counts[5] > 0);
+  return flag ? 30 : 0;
+};
+
+const calYatch = (counts) => {
+  const flag = counts.some((v) => v == 5);
+  return flag ? 50 : 0;
+};
+
+export {
+  makeCountArray,
+  calSum,
+  calSingle,
+  cal4OfAKind,
+  calFullHouse,
+  calSmallStraight,
+  calLargeStraight,
+  calYatch,
+};

--- a/src/components/Friends/FriendsList.jsx
+++ b/src/components/Friends/FriendsList.jsx
@@ -34,7 +34,6 @@ export default function ({ friendsList, tabNumber }) {
   };
 
   const navigatePlay = () => {
-    console.log("::L");
     navigation.navigate("Play");
   };
   return (

--- a/src/components/Play/Pedigree.jsx
+++ b/src/components/Play/Pedigree.jsx
@@ -15,6 +15,7 @@ import {
   dice5,
   dice6,
 } from "../../../assets/play";
+import * as pc from "../../PedigreeCalculator";
 
 const IMAGES = {
   Aces: dice1,
@@ -44,6 +45,8 @@ export default function ({
   holdabled,
   holdPedigreeHandler,
   hold,
+  dices,
+  rollCount,
 }) {
   return (
     <Container>
@@ -61,10 +64,21 @@ export default function ({
         hold={hold && isTurn}
         yellow
       >
-        <ScoreText> {myScore} </ScoreText>
+        {!myScore && rollCount !== 0 && isTurn ? (
+          <>
+            {console.log(rollCount)}
+            <ScoreText gray> {pc.calculate(title, dices)} </ScoreText>
+          </>
+        ) : (
+          <ScoreText> {myScore} </ScoreText>
+        )}
       </ScoreContainer>
       <ScoreContainer disabled={true} hold={hold && !isTurn}>
-        <ScoreText> {rivalScore} </ScoreText>
+        {!rivalScore && rollCount !== 0 && !isTurn ? (
+          <ScoreText gray> {pc.calculate(title, dices)} </ScoreText>
+        ) : (
+          <ScoreText> {rivalScore} </ScoreText>
+        )}
       </ScoreContainer>
     </Container>
   );
@@ -108,8 +122,7 @@ const ScoreContainer = styled.TouchableOpacity`
 `;
 
 const ScoreText = styled.Text`
-  color: gray;
-
+  color: ${(props) => (props.gray ? "gray" : "")};
   font-size: 15px;
   font-weight: bold;
 `;

--- a/src/components/Play/Pedigree.jsx
+++ b/src/components/Play/Pedigree.jsx
@@ -65,10 +65,7 @@ export default function ({
         yellow
       >
         {!myScore && rollCount !== 0 && isTurn ? (
-          <>
-            {console.log(rollCount)}
-            <ScoreText gray> {pc.calculate(title, dices)} </ScoreText>
-          </>
+          <ScoreText gray> {pc.calculate(title, dices)} </ScoreText>
         ) : (
           <ScoreText> {myScore} </ScoreText>
         )}

--- a/src/components/Play/Pedigree.jsx
+++ b/src/components/Play/Pedigree.jsx
@@ -36,7 +36,15 @@ const getImage = (title) => {
   return IMAGES[title];
 };
 
-export default function ({ title, myScore, rivalScore }) {
+export default function ({
+  title,
+  myScore,
+  rivalScore,
+  isTurn,
+  holdabled,
+  holdPedigreeHandler,
+  hold,
+}) {
   return (
     <Container>
       <DiceContainer>
@@ -47,10 +55,17 @@ export default function ({ title, myScore, rivalScore }) {
           <Text>{title}</Text>
         </TextContainer>
       </DiceContainer>
-      <MyScore>
-        <MyScoreText>{myScore}</MyScoreText>
-      </MyScore>
-      <RivalScore>{rivalScore}</RivalScore>
+      <ScoreContainer
+        disabled={!holdabled}
+        onPress={() => holdPedigreeHandler(title)}
+        hold={hold && isTurn}
+        yellow
+      >
+        <ScoreText> {myScore} </ScoreText>
+      </ScoreContainer>
+      <ScoreContainer disabled={true} hold={hold && !isTurn}>
+        <ScoreText> {rivalScore} </ScoreText>
+      </ScoreContainer>
     </Container>
   );
 }
@@ -59,12 +74,12 @@ const Container = styled.View`
   flex: 1;
   flex-direction: row;
   margin-vertical: 1px;
+  border-width: 1px;
 `;
 const DiceContainer = styled.View`
   flex: 2;
   flex-direction: row;
   justify-content: flex-start;
-  border-width: 1px;
 `;
 const ImageContainer = styled.View`
   align-items: center;
@@ -84,22 +99,17 @@ const TextContainer = styled.View`
 const Text = styled.Text`
   font-size: 13px;
 `;
-const MyScore = styled.View`
+const ScoreContainer = styled.TouchableOpacity`
   flex: 1;
-  border-width: 1px;
-  background-color: #ffc000;
+  border-width: ${(props) => (props.hold ? "2px" : "")};
+  background-color: ${(props) => (props.yellow ? "#ffc000" : "")};
   justify-content: center;
   align-items: center;
 `;
 
-const MyScoreText = styled.Text`
+const ScoreText = styled.Text`
   color: gray;
 
   font-size: 15px;
   font-weight: bold;
-`;
-
-const RivalScore = styled.View`
-  flex: 1;
-  border-width: 1px;
 `;

--- a/src/screens/PlayScreen/PlayScreenContainer.jsx
+++ b/src/screens/PlayScreen/PlayScreenContainer.jsx
@@ -4,6 +4,7 @@ import { BackHandler, StatusBar } from "react-native";
 import { socket, connectSocket } from "../../socket";
 import PlayScreenPresenter from "./PlayScreenPresenter";
 import { Matching } from "../../components/Matching/Matching";
+import * as pc from "../../PedigreeCalculator";
 
 export default function () {
   const [isMatched, setIsMatched] = useState(false);
@@ -29,11 +30,7 @@ export default function () {
   };
 
   const rollHandler = () => {
-    const data = new Object();
-    data.dices = dices;
-    data.holddDices = holdDices;
-    data.rollCount = rollCount;
-    socket.emit("roll", data);
+    socket.emit("roll", holdDices);
   };
 
   const holdPedigreeHandler = (title) => {
@@ -65,15 +62,26 @@ export default function () {
     // roll
     socket.on("rollDices", (data) => {
       setDices(data);
+      // 족보 계산값
+      const counts = pc.makeCountArray(data);
+      const calculatedData = {
+        Aces: pc.calSingle(counts, 1),
+        Duces: pc.calSingle(counts, 2),
+        Threes: pc.calSingle(counts, 3),
+        Fours: pc.calSingle(counts, 4),
+        Fives: pc.calSingle(counts, 5),
+        Sixes: pc.calSingle(counts, 6),
+        Choice: pc.calSum(counts),
+        "4 Of a Kind": pc.cal4OfAKind(counts),
+        "Full House": pc.calFullHouse(counts),
+        "Small Straight": pc.calSmallStraight(counts),
+        "Large Straight": pc.calLargeStraight(counts),
+        Yacht: pc.calYatch(counts),
+      };
+      setMyScore(calculatedData);
     });
     socket.on("countRolls", (data) => {
       setRollCount(data);
-    });
-    socket.on("preCalculateMyScore", (data) => {
-      setMyScore(data);
-    });
-    socket.on("preCalculateRivalScore", (data) => {
-      setRivalScore(data);
     });
 
     socket.on("hold", (data) => {

--- a/src/screens/PlayScreen/PlayScreenContainer.jsx
+++ b/src/screens/PlayScreen/PlayScreenContainer.jsx
@@ -61,16 +61,16 @@ export default function () {
       setIsMatched(true);
     });
 
-    socket.on("pre_calcurate", (data) => {
+    socket.on("preCalculate", (data) => {
       setMyScore(data);
     });
 
     // roll dices
-    socket.on("roll", (data) => {
+    socket.on("rollDices", (data) => {
       setDices(data);
     });
 
-    socket.on("roll_count", (data) => {
+    socket.on("countRolls", (data) => {
       setRollCount(data);
     });
 

--- a/src/screens/PlayScreen/PlayScreenContainer.jsx
+++ b/src/screens/PlayScreen/PlayScreenContainer.jsx
@@ -17,7 +17,9 @@ export default function () {
   ]);
   const [dices, setDices] = useState([1, 2, 3, 4, 5]);
   const [myScore, setMyScore] = useState({});
+  const [rivalScore, setRivalScore] = useState({});
   const [rollCount, setRollCount] = useState(0);
+  const [holdPedigreeTitle, setHoldPedigreeTitle] = useState("");
 
   const emitHoldDices = (number) => {
     let dices = holdDices.slice();
@@ -34,6 +36,9 @@ export default function () {
     socket.emit("roll", data);
   };
 
+  const holdPedigreeHandler = (title) => {
+    socket.emit("holdPedigree", title);
+  };
   const submitHandler = () => {
     socket.emit("submit");
   };
@@ -53,25 +58,29 @@ export default function () {
 
     socket.emit("matching");
 
-    socket.on("hold", (data) => {
-      setHoldDices(data);
-    });
-
     socket.on("matched", (data) => {
       setIsMatched(true);
     });
 
-    socket.on("preCalculate", (data) => {
-      setMyScore(data);
-    });
-
-    // roll dices
+    // roll
     socket.on("rollDices", (data) => {
       setDices(data);
     });
-
     socket.on("countRolls", (data) => {
       setRollCount(data);
+    });
+    socket.on("preCalculateMyScore", (data) => {
+      setMyScore(data);
+    });
+    socket.on("preCalculateRivalScore", (data) => {
+      setRivalScore(data);
+    });
+
+    socket.on("hold", (data) => {
+      setHoldDices(data);
+    });
+    socket.on("holdPedigree", (data) => {
+      setHoldPedigreeTitle(data);
     });
 
     socket.on("submit", (data) => {
@@ -93,11 +102,14 @@ export default function () {
         {...{
           isTurn,
           dices,
-          holdDices,
-          emitHoldDices,
-          rollHandler,
           rollCount,
           myScore,
+          rivalScore,
+          holdDices,
+          holdPedigreeTitle,
+          holdPedigreeHandler,
+          rollHandler,
+          emitHoldDices,
           submitHandler,
         }}
       />

--- a/src/screens/PlayScreen/PlayScreenContainer.jsx
+++ b/src/screens/PlayScreen/PlayScreenContainer.jsx
@@ -16,7 +16,7 @@ export default function () {
     false,
     false,
   ]);
-  const [dices, setDices] = useState([1, 2, 3, 4, 5]);
+  const [dices, setDices] = useState([]);
   const [myScore, setMyScore] = useState({});
   const [rivalScore, setRivalScore] = useState({});
   const [rollCount, setRollCount] = useState(0);
@@ -63,22 +63,22 @@ export default function () {
     socket.on("rollDices", (data) => {
       setDices(data);
       // 족보 계산값
-      const counts = pc.makeCountArray(data);
-      const calculatedData = {
-        Aces: pc.calSingle(counts, 1),
-        Duces: pc.calSingle(counts, 2),
-        Threes: pc.calSingle(counts, 3),
-        Fours: pc.calSingle(counts, 4),
-        Fives: pc.calSingle(counts, 5),
-        Sixes: pc.calSingle(counts, 6),
-        Choice: pc.calSum(counts),
-        "4 Of a Kind": pc.cal4OfAKind(counts),
-        "Full House": pc.calFullHouse(counts),
-        "Small Straight": pc.calSmallStraight(counts),
-        "Large Straight": pc.calLargeStraight(counts),
-        Yacht: pc.calYatch(counts),
-      };
-      setMyScore(calculatedData);
+      // const counts = pc.makeCountArray(data);
+      // const calculatedData = {
+      //   Aces: pc.calSingle(counts, 1),
+      //   Duces: pc.calSingle(counts, 2),
+      //   Threes: pc.calSingle(counts, 3),
+      //   Fours: pc.calSingle(counts, 4),
+      //   Fives: pc.calSingle(counts, 5),
+      //   Sixes: pc.calSingle(counts, 6),
+      //   Choice: pc.calSum(counts),
+      //   "4 Of a Kind": pc.cal4OfAKind(counts),
+      //   "Full House": pc.calFullHouse(counts),
+      //   "Small Straight": pc.calSmallStraight(counts),
+      //   "Large Straight": pc.calLargeStraight(counts),
+      //   Yacht: pc.calYatch(counts),
+      // };
+      // setMyScore(calculatedData);
     });
     socket.on("countRolls", (data) => {
       setRollCount(data);
@@ -93,6 +93,14 @@ export default function () {
 
     socket.on("submit", (data) => {
       setIsTurn(data);
+    });
+
+    socket.on("updateScore", (score, isMine) => {
+      if (isMine) {
+        setMyScore(score);
+      } else {
+        setRivalScore(score);
+      }
     });
 
     // WillUnmount

--- a/src/screens/PlayScreen/PlayScreenPresenter.jsx
+++ b/src/screens/PlayScreen/PlayScreenPresenter.jsx
@@ -26,9 +26,11 @@ export default function ({
               title={title}
               myScore={myScore[title]}
               rivalScore={rivalScore[title]}
-              holdabled={isTurn && rollCount !== 0}
+              holdabled={isTurn && rollCount !== 0 && !myScore[title]}
               holdPedigreeHandler={holdPedigreeHandler}
               hold={title === holdPedigreeTitle}
+              dices={dices}
+              rollCount={rollCount}
             />
           ))}
           <TotalContainer>
@@ -44,9 +46,11 @@ export default function ({
               title={title}
               myScore={myScore[title]}
               rivalScore={rivalScore[title]}
-              holdabled={isTurn && rollCount !== 0}
+              holdabled={isTurn && rollCount !== 0 && !myScore[title]}
               holdPedigreeHandler={holdPedigreeHandler}
               hold={title === holdPedigreeTitle}
+              rollCount={rollCount}
+              dices={dices}
             />
           ))}
           <TotalContainer>

--- a/src/screens/PlayScreen/PlayScreenPresenter.jsx
+++ b/src/screens/PlayScreen/PlayScreenPresenter.jsx
@@ -5,11 +5,14 @@ import { leftPedigreeTitles, rightPedigreeTitles } from "./PedigreeTitle";
 export default function ({
   isTurn,
   dices,
-  holdDices,
-  emitHoldDices,
-  rollHandler,
   rollCount,
   myScore,
+  rivalScore,
+  holdDices,
+  holdPedigreeTitle,
+  holdPedigreeHandler,
+  rollHandler,
+  emitHoldDices,
   submitHandler,
 }) {
   return (
@@ -17,7 +20,16 @@ export default function ({
       <PedigreeContainer>
         <PedigreeList>
           {leftPedigreeTitles.map((title, index) => (
-            <Pedigree key={index} title={title} myScore={myScore[title]} />
+            <Pedigree
+              key={index}
+              isTurn={isTurn}
+              title={title}
+              myScore={myScore[title]}
+              rivalScore={rivalScore[title]}
+              holdabled={isTurn && rollCount !== 0}
+              holdPedigreeHandler={holdPedigreeHandler}
+              hold={title === holdPedigreeTitle}
+            />
           ))}
           <TotalContainer>
             <Total title="Bonus" myScore="2" rivalScore="50" />
@@ -26,7 +38,16 @@ export default function ({
 
         <PedigreeList>
           {rightPedigreeTitles.map((title, index) => (
-            <Pedigree key={index} title={title} myScore={myScore[title]} />
+            <Pedigree
+              key={index}
+              isTurn={isTurn}
+              title={title}
+              myScore={myScore[title]}
+              rivalScore={rivalScore[title]}
+              holdabled={isTurn && rollCount !== 0}
+              holdPedigreeHandler={holdPedigreeHandler}
+              hold={title === holdPedigreeTitle}
+            />
           ))}
           <TotalContainer>
             <Total title="Total" myScore="133" rivalScore="350" />
@@ -63,7 +84,10 @@ export default function ({
           <ButtonText>Roll</ButtonText>
         </Button>
         {rollCount !== 0 ? (
-          <Button disabled={!isTurn} onPress={submitHandler}>
+          <Button
+            disabled={!isTurn || holdPedigreeTitle === ""}
+            onPress={submitHandler}
+          >
             <ButtonText>Submit</ButtonText>
           </Button>
         ) : (

--- a/src/screens/PlayScreen/PlayScreenPresenter.jsx
+++ b/src/screens/PlayScreen/PlayScreenPresenter.jsx
@@ -33,19 +33,30 @@ export default function ({
           </TotalContainer>
         </PedigreeList>
       </PedigreeContainer>
-      <RollCountContainer>
+      <TextContainer>
+        <TurnText> {isTurn ? "내 차례" : "상대 차례"} </TurnText>
         <RollCountText> {3 - rollCount} remains </RollCountText>
-      </RollCountContainer>
+      </TextContainer>
       <DiceContainer>
-        {dices.map((value, index) => (
-          <Dice
-            disabled={!isTurn || rollCount === 0}
-            key={index}
-            hold={holdDices[index]}
-            value={value}
-            onPress={() => emitHoldDices(index)}
-          />
-        ))}
+        {rollCount === 0 ? (
+          <>
+            <DiceText>
+              {isTurn ? "주사위를 굴려주세요" : "상대 차례입니다"}
+            </DiceText>
+          </>
+        ) : (
+          <>
+            {dices.map((value, index) => (
+              <Dice
+                disabled={!isTurn || rollCount === 0}
+                key={index}
+                hold={holdDices[index]}
+                value={value}
+                onPress={() => emitHoldDices(index)}
+              />
+            ))}
+          </>
+        )}
       </DiceContainer>
       <ButtonContainer>
         <Button disabled={!isTurn || rollCount === 3} onPress={rollHandler}>
@@ -89,14 +100,19 @@ const DiceContainer = styled.View`
   justify-content: center;
 `;
 
-const RollCountContainer = styled.View`
-  flex: 0.5;
-  margin-horizontal: 10px;
+const DiceText = styled.Text`
+  font-size: 24px;
+  font-weight: bold;
 `;
 
-const RollCountText = styled.Text`
-  text-align: right;
+const TextContainer = styled.View`
+  flex-direction: row;
+  flex: 0.5;
+  justify-content: space-between;
+  margin-horizontal: 10px;
 `;
+const TurnText = styled.Text``;
+const RollCountText = styled.Text``;
 
 const ButtonContainer = styled.View`
   flex: 1;
@@ -104,7 +120,6 @@ const ButtonContainer = styled.View`
   margin-vertical: 20px;
   margin-horizontal: 10px;
 `;
-// visibility: ${(props) => (props.isTurn ? "visible " : "hidden")};
 
 const Button = styled.TouchableOpacity`
   flex: 1;
@@ -118,4 +133,3 @@ const Button = styled.TouchableOpacity`
 `;
 
 const ButtonText = styled.Text``;
-// background-color: white;


### PR DESCRIPTION
## 내용
족보에 대한 값을 조건에 따라 보이게 끔 구현하였습니다.
족보를 클릭할 수 없게 끔 disable 조건에 따라 구현하였습니다.



## 스크린샷
![#23](https://user-images.githubusercontent.com/31649100/109295837-c6180580-7872-11eb-83d9-2db460afc30c.gif)

## 향후 개발
보너스와 합계, 게임종료 상황을 구현할 계획입니다.

기존의 계획했던 한 핸들러당 한 개의 상태관리를 수정할 필요가 있습니다.
위의 스크린샷을 보시면 여러개의 핸들러로 상태값을 관리하기 때문에, 다른 상태를 받기 전까지 의도치 않은 화면이 보이는 경우가 생깁니다.

또한 PedigreePresenter와, Pedigree에서 여러개의 props를 받아, 코드가 지저분해보였습니다.

현재는 위 문제들을 해결하기위해 게임 관련 상태들을 하나의 객체 형태로 변경하는 방법을 생각 중입니다. 
다른 좋은 방법이 있으면 알려주시면 감사하겠습니다. 


